### PR TITLE
target Makefile update; pre-commit formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 PACKAGE_NAME  := descent-workflow
-CONDA_ENV_RUN := conda run --no-capture-output --name $(PACKAGE_NAME)
+
+# Detect which conda package manager is available
+CONDA_CMD := $(shell \
+	if command -v micromamba >/dev/null 2>&1; then \
+		echo "micromamba"; \
+	elif command -v mamba >/dev/null 2>&1; then \
+		echo "mamba"; \
+	elif command -v conda >/dev/null 2>&1; then \
+		echo "conda"; \
+	else \
+		echo "conda"; \
+	fi)
+
+CONDA_ENV_RUN := $(CONDA_CMD) run -a "" --name $(PACKAGE_NAME)
 
 .PHONY: env lint format
 
 env:
-	mamba create     --name $(PACKAGE_NAME)
-	mamba env update --name $(PACKAGE_NAME) --file environment.yaml
+	$(CONDA_CMD) create     --name $(PACKAGE_NAME)
+	$(CONDA_CMD) env update --name $(PACKAGE_NAME) --file environment.yaml
 	$(CONDA_ENV_RUN) pre-commit install || true
 
 lint:

--- a/workflow/analysis/compare_ffs.ipynb
+++ b/workflow/analysis/compare_ffs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "01c85986",
    "metadata": {},
    "outputs": [
@@ -15,28 +15,24 @@
     }
    ],
    "source": [
-    "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.style.use('ggplot')\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
+    "\n",
     "from typing import Literal\n",
     "from tqdm import tqdm\n",
     "\n",
-    "from openff.toolkit.topology import Molecule\n",
-    "from openff.toolkit.topology import Topology\n",
     "from openff.toolkit.typing.engines.smirnoff import ForceField\n",
-    "from openff.interchange.components.interchange import Interchange\n",
     "from openff import units\n",
     "\n",
-    "from dataclasses import dataclass\n",
+    "plt.style.use(\"ggplot\")\n",
     "\n",
-    "POTENTIAL_KEYS = Literal[\"Bonds\", \"Angles\", \"ProperTorsions\", \"ImproperTorsions\", \"vdW\", \"Electrostatics\"]"
+    "POTENTIAL_KEYS = Literal[\n",
+    "    \"Bonds\", \"Angles\", \"ProperTorsions\", \"ImproperTorsions\", \"vdW\", \"Electrostatics\"\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8a9ef68c",
    "metadata": {},
    "outputs": [
@@ -53,54 +49,71 @@
     }
    ],
    "source": [
-    "pot_types_and_param_keys = {\"Bonds\": [\"length\", \"k\"],\n",
-    "                            \"Angles\": [\"angle\", \"k\"],\n",
-    "                            \"ProperTorsions\": [\"k1\", \"k2\", \"k3\", \"k4\", \"phase1\", \"phase2\", \"phase3\", \"phase4\"],\n",
-    "                            \"ImproperTorsions\": [\"k1\", \"phase1\"],\n",
-    "                            }\n",
+    "pot_types_and_param_keys = {\n",
+    "    \"Bonds\": [\"length\", \"k\"],\n",
+    "    \"Angles\": [\"angle\", \"k\"],\n",
+    "    \"ProperTorsions\": [\"k1\", \"k2\", \"k3\", \"k4\", \"phase1\", \"phase2\", \"phase3\", \"phase4\"],\n",
+    "    \"ImproperTorsions\": [\"k1\", \"phase1\"],\n",
+    "}\n",
     "\n",
-    "def plot_all_ffs(output_data: OutputData, plot_type: Literal[\"values\", \"differences\"]) -> tuple[plt.Figure, plt.Axes]:\n",
-    "    \n",
-    "    plt_fn = plot_ff_values if plot_type == \"values\" else plot_ff_differences\n",
-    "    extra_args = {\"iterations\": (0, output_data.n_iter-1)} if plot_type == \"differences\" else {}\n",
     "\n",
-    "    # 1 column per potential type\n",
-    "    ncols = len(pot_types_and_param_keys)\n",
-    "    # 1 row for each of the greatest number of parameters\n",
-    "    nrows = max([len(v) for v in pot_types_and_param_keys.values()])\n",
-    "    fig, axs = plt.subplots(nrows, ncols, figsize=(ncols*5, nrows*5))\n",
-    "\n",
-    "    for i, (potential_type, param_keys) in tqdm(enumerate(pot_types_and_param_keys.items()), total=len(pot_types_and_param_keys)):\n",
-    "        for j, param_key in enumerate(param_keys):\n",
-    "            plt_fn(fig, axs[j, i], output_data, potential_type, param_key, **extra_args)\n",
-    "\n",
-    "        # Hide the remaining axes\n",
-    "        for k in range(j+1, nrows):\n",
-    "            axs[k, i].axis(\"off\")\n",
-    "\n",
-    "    axs[2, 3].legend(bbox_to_anchor=(1.05, 1), loc='upper left')\n",
-    "\n",
-    "    fig.tight_layout()\n",
-    "\n",
-    "    return fig, axs\n"
+    "# def plot_all_ffs(\n",
+    "#    output_data: OutputData, plot_type: Literal[\"values\", \"differences\"]\n",
+    "# ) -> tuple[plt.Figure, plt.Axes]:\n",
+    "#    plt_fn = plot_ff_values if plot_type == \"values\" else plot_ff_differences\n",
+    "#    extra_args = (\n",
+    "#        {\"iterations\": (0, output_data.n_iter - 1)}\n",
+    "#        if plot_type == \"differences\"\n",
+    "#        else {}\n",
+    "#    )\n",
+    "#\n",
+    "#    # 1 column per potential type\n",
+    "#    ncols = len(pot_types_and_param_keys)\n",
+    "#    # 1 row for each of the greatest number of parameters\n",
+    "#    nrows = max([len(v) for v in pot_types_and_param_keys.values()])\n",
+    "#    fig, axs = plt.subplots(nrows, ncols, figsize=(ncols * 5, nrows * 5))\n",
+    "#\n",
+    "#    for i, (potential_type, param_keys) in tqdm(\n",
+    "#        enumerate(pot_types_and_param_keys.items()), total=len(pot_types_and_param_keys)\n",
+    "#    ):\n",
+    "#        for j, param_key in enumerate(param_keys):\n",
+    "#            plt_fn(fig, axs[j, i], output_data, potential_type, param_key, **extra_args)\n",
+    "#\n",
+    "#        # Hide the remaining axes\n",
+    "#        for k in range(j + 1, nrows):\n",
+    "#            axs[k, i].axis(\"off\")\n",
+    "#\n",
+    "#    axs[2, 3].legend(bbox_to_anchor=(1.05, 1), loc=\"upper left\")\n",
+    "#\n",
+    "#    fig.tight_layout()\n",
+    "#\n",
+    "#    return fig, axs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "280ff690",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openff.toolkit import ForceField\n",
+    "# from openff.toolkit import ForceField\n",
     "\n",
-    "pot_types_and_param_keys = {\"Bonds\": [\"length\", \"k\"],\n",
-    "                            \"Angles\": [\"angle\", \"k\"],\n",
-    "                            \"ProperTorsions\": [\"k1\", \"k2\", \"k3\", \"k4\", \"phase1\", \"phase2\", \"phase3\", \"phase4\"],\n",
-    "                            \"ImproperTorsions\": [\"k1\", \"phase1\"],\n",
-    "                            }\n",
+    "pot_types_and_param_keys = {\n",
+    "    \"Bonds\": [\"length\", \"k\"],\n",
+    "    \"Angles\": [\"angle\", \"k\"],\n",
+    "    \"ProperTorsions\": [\"k1\", \"k2\", \"k3\", \"k4\", \"phase1\", \"phase2\", \"phase3\", \"phase4\"],\n",
+    "    \"ImproperTorsions\": [\"k1\", \"phase1\"],\n",
+    "}\n",
     "\n",
-    "def plot_parameters(fig: plt.Figure, ax: plt.Axes, force_field: ForceField,  potential_type: str, parameter_key: str) -> dict[str, float]:\n",
+    "\n",
+    "def plot_parameters(\n",
+    "    fig: plt.Figure,\n",
+    "    ax: plt.Axes,\n",
+    "    force_field: ForceField,\n",
+    "    potential_type: str,\n",
+    "    parameter_key: str,\n",
+    ") -> dict[str, float]:\n",
     "    \"\"\"\n",
     "    Plot the parameters for a given parameter key.\n",
     "    \"\"\"\n",
@@ -108,26 +121,34 @@
     "    objects = force_field.get_parameter_handler(potential_type).parameters\n",
     "    potentials = {p.id: p.to_dict() for p in objects}\n",
     "\n",
-    "    parameter_keys = [k for k in potentials[list(potentials.keys())[0]].keys() if k not in [\"smirks\", \"id\"]]\n",
+    "    parameter_keys = [\n",
+    "        k\n",
+    "        for k in potentials[list(potentials.keys())[0]].keys()\n",
+    "        if k not in [\"smirks\", \"id\"]\n",
+    "    ]\n",
     "    print(f\"Parameter keys: {parameter_keys}\")\n",
     "    if parameter_key not in parameter_keys:\n",
     "        raise ValueError(f\"Parameter key {parameter_key} not found in {parameter_keys}\")\n",
     "\n",
-    "    \n",
     "    # Get the differences for each key id\n",
     "    vals = {key: potentials[key][parameter_key] for key in potentials.keys()}\n",
     "    vals_first_key = list(vals.keys())[0]\n",
     "\n",
     "    # Plot the differences\n",
-    "    q_units = units.unit.degrees if potential_type == \"Angles\" and parameter_key == \"angle\" else vals[vals_first_key].units\n",
+    "    q_units = (\n",
+    "        units.unit.degrees\n",
+    "        if potential_type == \"Angles\" and parameter_key == \"angle\"\n",
+    "        else vals[vals_first_key].units\n",
+    "    )\n",
     "    ax.bar(\n",
     "        vals.keys(),\n",
-    "        [float(vals[k] / q_units ) for k in vals.keys()],\n",
+    "        [float(vals[k] / q_units) for k in vals.keys()],\n",
     "    )\n",
     "\n",
     "    ax.set_ylabel(f\"{parameter_key} / {q_units}\")\n",
     "    ax.set_xlabel(\"Key ID\")\n",
     "    ax.set_title(f\"{potential_type} {parameter_key}\")\n",
+    "\n",
     "\n",
     "def plot_forcefield(force_field: ForceField) -> tuple[plt.Figure, plt.Axes]:\n",
     "    \"\"\"\n",
@@ -137,18 +158,20 @@
     "    ncols = len(pot_types_and_param_keys)\n",
     "    # 1 row for each of the greatest number of parameters\n",
     "    nrows = max([len(v) for v in pot_types_and_param_keys.values()])\n",
-    "    fig, axs = plt.subplots(nrows, ncols, figsize=(ncols*5, nrows*5))\n",
+    "    fig, axs = plt.subplots(nrows, ncols, figsize=(ncols * 5, nrows * 5))\n",
     "\n",
-    "    for i, (potential_type, param_keys) in tqdm(enumerate(pot_types_and_param_keys.items()), total=len(pot_types_and_param_keys)):\n",
+    "    for i, (potential_type, param_keys) in tqdm(\n",
+    "        enumerate(pot_types_and_param_keys.items()), total=len(pot_types_and_param_keys)\n",
+    "    ):\n",
     "        for j, param_key in enumerate(param_keys):\n",
     "            print(f\"Plotting {potential_type} {param_key}\")\n",
     "            plot_parameters(fig, axs[j, i], force_field, potential_type, param_key)\n",
     "\n",
     "        # Hide the remaining axes\n",
-    "        for k in range(j+1, nrows):\n",
+    "        for k in range(j + 1, nrows):\n",
     "            axs[k, i].axis(\"off\")\n",
     "\n",
-    "    axs[2, 3].legend(bbox_to_anchor=(1.05, 1), loc='upper left')\n",
+    "    axs[2, 3].legend(bbox_to_anchor=(1.05, 1), loc=\"upper left\")\n",
     "\n",
     "    fig.tight_layout()\n",
     "\n",
@@ -162,11 +185,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ff_names = [#\"spice-2-lj-sage-2-2-msm-expanded-torsions\",\n",
-    "            #\"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\", \n",
-    "            \"../output_ff/spice2_linearised_harmonics_improper_reg\"\n",
-    "           ]\n",
-    "ffs = {name.split(\"/\")[-1]: ForceField(f\"../output_ff/{name}.offxml\") for name in ff_names}"
+    "ff_names = [  # \"spice-2-lj-sage-2-2-msm-expanded-torsions\",\n",
+    "    # \"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\",\n",
+    "    \"../output_ff/spice2_linearised_harmonics_improper_reg\"\n",
+    "]\n",
+    "ffs = {\n",
+    "    name.split(\"/\")[-1]: ForceField(f\"../output_ff/{name}.offxml\") for name in ff_names\n",
+    "}"
    ]
   },
   {
@@ -289,7 +314,7 @@
     "for ff_name, ff in ffs.items():\n",
     "    print(f\"Force field: {ff_name}\")\n",
     "    fig, ax = plot_forcefield(ff)\n",
-    "    fig.savefig(f\"{ff_name}.png\", dpi=300, bbox_inches='tight')"
+    "    fig.savefig(f\"{ff_name}.png\", dpi=300, bbox_inches=\"tight\")"
    ]
   },
   {
@@ -393,8 +418,10 @@
     }
    ],
    "source": [
-    "fig, ax = plot_forcefield(ffs[\"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\"])\n",
-    "fig.savefig(\"spice2-linear-harm.png\", dpi=300, bbox_inches='tight')"
+    "fig, ax = plot_forcefield(\n",
+    "    ffs[\"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\"]\n",
+    ")\n",
+    "fig.savefig(\"spice2-linear-harm.png\", dpi=300, bbox_inches=\"tight\")"
    ]
   },
   {
@@ -472,7 +499,7 @@
    ],
    "source": [
     "fig, axs = plot_forcefield(ffs[\"spice-2-lj-sage-2-2-msm-expanded-torsions\"])\n",
-    "fig.savefig(\"spice2.png\", dpi=300, bbox_inches='tight')"
+    "fig.savefig(\"spice2.png\", dpi=300, bbox_inches=\"tight\")"
    ]
   },
   {
@@ -510,7 +537,9 @@
     }
    ],
    "source": [
-    "ffs[\"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\"].get_parameter_handler(\"ProperTorsions\").parameters[0].to_dict()"
+    "ffs[\n",
+    "    \"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2\"\n",
+    "].get_parameter_handler(\"ProperTorsions\").parameters[0].to_dict()"
    ]
   },
   {
@@ -548,7 +577,9 @@
     }
    ],
    "source": [
-    "ffs[\"spice-2-lj-sage-2-2-msm-expanded-torsions\"].get_parameter_handler(\"ProperTorsions\").parameters[0].to_dict()"
+    "ffs[\"spice-2-lj-sage-2-2-msm-expanded-torsions\"].get_parameter_handler(\n",
+    "    \"ProperTorsions\"\n",
+    ").parameters[0].to_dict()"
    ]
   },
   {

--- a/workflow/analysis/learning_dynamics.ipynb
+++ b/workflow/analysis/learning_dynamics.ipynb
@@ -21,7 +21,6 @@
     "import numpy as np\n",
     "import numpy.typing as npt\n",
     "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns\n",
     "from openff import units\n",
     "from pint import Unit\n",
     "from smee import TensorForceField\n",
@@ -33,8 +32,11 @@
     "\n",
     "plt.style.use(\"ggplot\")\n",
     "\n",
+    "\n",
     "# Mainly written by Josh Horton\n",
-    "def pt_ff_to_off_ff(base_force_field: ForceField, tensor_force_field: TensorForceField) -> ForceField:\n",
+    "def pt_ff_to_off_ff(\n",
+    "    base_force_field: ForceField, tensor_force_field: TensorForceField\n",
+    ") -> ForceField:\n",
     "    \"\"\"Convert the FF from pt to OFF ForceField format.\"\"\"\n",
     "\n",
     "    # Copy the base force field to avoid modifying it\n",
@@ -54,16 +56,24 @@
     "                opt_parameters = potential.parameters[i].detach().cpu()\n",
     "                for j, (p, unit) in enumerate(zip(parameter_names, parameter_units)):\n",
     "                    setattr(ff_parameter, p, opt_parameters[j] * unit)\n",
-    "        \n",
+    "\n",
     "        if potential_type in [\"LinearBonds\", \"LinearAngles\"]:\n",
-    "            handler = base_force_field.get_parameter_handler(potential_type.replace(\"Linear\", \"\"))\n",
+    "            handler = base_force_field.get_parameter_handler(\n",
+    "                potential_type.replace(\"Linear\", \"\")\n",
+    "            )\n",
     "            for i in range(len(potential.parameters)):\n",
     "                smirks = potential.parameter_keys[i].id\n",
     "                ff_parameter = handler[smirks]\n",
     "                opt_linear_parameters = potential.parameters[i].detach().cpu()\n",
     "                # Convert linear parameters back to harmonic parameters\n",
-    "                k1, k2 = opt_linear_parameters[0].item(), opt_linear_parameters[1].item()\n",
-    "                b1, b2 = opt_linear_parameters[2].item(), opt_linear_parameters[3].item()\n",
+    "                k1, k2 = (\n",
+    "                    opt_linear_parameters[0].item(),\n",
+    "                    opt_linear_parameters[1].item(),\n",
+    "                )\n",
+    "                b1, b2 = (\n",
+    "                    opt_linear_parameters[2].item(),\n",
+    "                    opt_linear_parameters[3].item(),\n",
+    "                )\n",
     "                k = k1 + k2\n",
     "                b = (b1 * k1 + b2 * k2) / k\n",
     "                # logger.info(f\"Converting {smirks} from linear to harmonic\")\n",
@@ -75,7 +85,7 @@
     "                    # Convert to kcal mol-1 deg -2 (from kcal mol-1 rad -2)\n",
     "                    ff_parameter.k = k * parameter_units[0]\n",
     "                    ff_parameter.angle = b * parameter_units[2]\n",
-    "        \n",
+    "\n",
     "        elif potential_type in [\"ProperTorsions\"]:\n",
     "            handler = base_force_field.get_parameter_handler(potential_type)\n",
     "            # we need to collect the k values into a list accross the entries\n",
@@ -86,9 +96,9 @@
     "                    collection_data[smirks] = {}\n",
     "                opt_parameters = potential.parameters[i].detach().cpu()\n",
     "                # find k and the perodicity\n",
-    "                k_index = parameter_names.index('k')\n",
+    "                k_index = parameter_names.index(\"k\")\n",
     "                k = opt_parameters[k_index] * parameter_units[k_index]\n",
-    "                p = int(opt_parameters[parameter_names.index('periodicity')])\n",
+    "                p = int(opt_parameters[parameter_names.index(\"periodicity\")])\n",
     "                collection_data[smirks][p] = k\n",
     "            # now update the force field\n",
     "            for smirks, tor_data in collection_data.items():\n",
@@ -105,11 +115,11 @@
     "            for i in range(len(potential.parameters)):\n",
     "                smirks = potential.parameter_keys[i].id\n",
     "                opt_parameters = potential.parameters[i].detach().cpu()\n",
-    "                k_index = parameter_names.index('k')\n",
+    "                k_index = parameter_names.index(\"k\")\n",
     "                ff_parameter = handler[smirks]\n",
     "                ff_parameter.k = [opt_parameters[k_index] * parameter_units[k_index]]\n",
     "\n",
-    "    return base_force_field\n"
+    "    return base_force_field"
    ]
   },
   {
@@ -119,7 +129,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spice2_linear_harm = ForceField(\"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2.offxml\")\n",
+    "spice2_linear_harm = ForceField(\n",
+    "    \"lj-sage-msm-0-torsions-linear-harm-trained-1000-epoch-spice2.offxml\"\n",
+    ")\n",
     "spice2 = ForceField(\"spice-2-lj-sage-2-2-msm-expanded-torsions.offxml\")"
    ]
   },
@@ -142,14 +154,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_param_values(force_field: ForceField, potential_type: str, parameter_key: str) -> tuple[list[str], Unit, npt.NDArray[np.float64]]:\n",
+    "def get_param_values(\n",
+    "    force_field: ForceField, potential_type: str, parameter_key: str\n",
+    ") -> tuple[list[str], Unit, npt.NDArray[np.float64]]:\n",
     "    \"\"\"Get the values of a parameter for a given potential type and parameter key.\"\"\"\n",
     "\n",
     "    params = force_field.get_parameter_handler(potential_type).parameters\n",
     "    param_names = [f\"{p.id}_{parameter_key}\" for p in params]\n",
     "    param_vals_with_units = [p.to_dict()[parameter_key] for p in params]\n",
-    "    param_units = units.unit.degrees if potential_type == \"Angles\" and parameter_key == \"angle\" else param_vals_with_units[0].units\n",
-    "    param_vals_unitless = np.array([float(v / param_units) for v in param_vals_with_units], dtype=np.float64)\n",
+    "    param_units = (\n",
+    "        units.unit.degrees\n",
+    "        if potential_type == \"Angles\" and parameter_key == \"angle\"\n",
+    "        else param_vals_with_units[0].units\n",
+    "    )\n",
+    "    param_vals_unitless = np.array(\n",
+    "        [float(v / param_units) for v in param_vals_with_units], dtype=np.float64\n",
+    "    )\n",
     "\n",
     "    return param_names, param_units, param_vals_unitless"
    ]
@@ -161,7 +181,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_rms_param_values(force_fields: list[ForceField], potential_type: str, parameter_key: str) -> tuple[Unit, npt.NDArray[np.float64]]:\n",
+    "def get_rms_param_values(\n",
+    "    force_fields: list[ForceField], potential_type: str, parameter_key: str\n",
+    ") -> tuple[Unit, npt.NDArray[np.float64]]:\n",
     "    \"\"\"Get the rms values of a parameter for a given potential type and parameter key.\"\"\"\n",
     "\n",
     "    param_vals_rmss = []\n",
@@ -206,13 +228,14 @@
     "        ncols=1,\n",
     "        figsize=(7, 4 * len(pot_types_and_param_keys)),\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    axes = axes.flatten() if len(pot_types_and_param_keys) > 1 else [axes]\n",
     "\n",
     "    for i, (pot_type, param_key) in enumerate(pot_types_and_param_keys):\n",
-    "        \n",
     "        for ff_name, force_fields_list in force_fields.items():\n",
-    "            param_units, rmse_param_vals = get_rms_param_values(force_fields_list, pot_type, param_key)\n",
+    "            param_units, rmse_param_vals = get_rms_param_values(\n",
+    "                force_fields_list, pot_type, param_key\n",
+    "            )\n",
     "\n",
     "            axes[i].plot(\n",
     "                range(len(force_fields_list)),\n",
@@ -252,7 +275,9 @@
     "    # Sort by the training number\n",
     "    ff_files = sorted(ff_files, key=lambda x: int(x.stem.split(\"-\")[-1]))\n",
     "    # Only include every 100th file\n",
-    "    ff_files = [ff_file for ff_file in ff_files if int(ff_file.stem.split(\"-\")[-1]) % 100 == 0]\n",
+    "    ff_files = [\n",
+    "        ff_file for ff_file in ff_files if int(ff_file.stem.split(\"-\")[-1]) % 100 == 0\n",
+    "    ]\n",
     "    print(ff_files)\n",
     "\n",
     "    xml_ffs = [pt_ff_to_off_ff(base_ff, torch.load(ff)) for ff in tqdm(ff_files)]\n",
@@ -311,10 +336,20 @@
    ],
    "source": [
     "base_ff = ForceField(\"spice-2-lj-sage-2-2-msm-expanded-torsions.offxml\")\n",
-    "xml_ffs = {\"spice2\": get_xml_ffs(Path(\"../../../SPICE-SMEE/fit-v2/fits/test/fit-20250321-220547\"), base_ff) ,\n",
-    "           \"spice2_lin_harm\": get_xml_ffs(Path(\"../../../SPICE-SMEE/fit-v5/fits/expanded_tor_linear/fit-20250418-135017/\"), base_ff),\n",
-    "           \"spice2_lin_harm_reg\": get_xml_ffs(Path(\"../fits/spice2_linearised_harmonics_improper_reg\"), base_ff),\n",
-    "        }"
+    "xml_ffs = {\n",
+    "    \"spice2\": get_xml_ffs(\n",
+    "        Path(\"../../../SPICE-SMEE/fit-v2/fits/test/fit-20250321-220547\"), base_ff\n",
+    "    ),\n",
+    "    \"spice2_lin_harm\": get_xml_ffs(\n",
+    "        Path(\n",
+    "            \"../../../SPICE-SMEE/fit-v5/fits/expanded_tor_linear/fit-20250418-135017/\"\n",
+    "        ),\n",
+    "        base_ff,\n",
+    "    ),\n",
+    "    \"spice2_lin_harm_reg\": get_xml_ffs(\n",
+    "        Path(\"../fits/spice2_linearised_harmonics_improper_reg\"), base_ff\n",
+    "    ),\n",
+    "}"
    ]
   },
   {
@@ -9158,8 +9193,12 @@
     }
    ],
    "source": [
-    "fig,axes = plot_param_trajectories(xml_ffs)\n",
-    "fig.savefig(\"spice2_linearised_harmonics_improper_reg_param_trajectories.png\", dpi=300, bbox_inches=\"tight\")"
+    "fig, axes = plot_param_trajectories(xml_ffs)\n",
+    "fig.savefig(\n",
+    "    \"spice2_linearised_harmonics_improper_reg_param_trajectories.png\",\n",
+    "    dpi=300,\n",
+    "    bbox_inches=\"tight\",\n",
+    ")"
    ]
   },
   {
@@ -17282,7 +17321,10 @@
    ],
    "source": [
     "base_ff = ForceField(\"spice-2-lj-sage-2-2-msm-expanded-torsions.offxml\")\n",
-    "xml_ffs = get_xml_ffs(Path(\"../../../SPICE-SMEE/fit-v5/fits/expanded_tor_linear/fit-20250418-135017/\"), base_ff)"
+    "xml_ffs = get_xml_ffs(\n",
+    "    Path(\"../../../SPICE-SMEE/fit-v5/fits/expanded_tor_linear/fit-20250418-135017/\"),\n",
+    "    base_ff,\n",
+    ")"
    ]
   },
   {
@@ -17303,7 +17345,7 @@
     }
    ],
    "source": [
-    "fig,axes = plot_param_trajectories(xml_ffs)\n",
+    "fig, axes = plot_param_trajectories(xml_ffs)\n",
     "fig.savefig(\"linear_tor_no_reg_param_trajectories.png\", dpi=300, bbox_inches=\"tight\")"
    ]
   },
@@ -22649,9 +22691,13 @@
     }
    ],
    "source": [
-    "xml_ffs = get_xml_ffs(Path(\"../../../SPICE-SMEE/fit-v2/fits/test/fit-20250321-220547\"), base_ff)\n",
-    "fig,axes = plot_param_trajectories(xml_ffs)\n",
-    "fig.savefig(\"expanded_tor_no_linear_harm_param_trajectories.png\", dpi=300, bbox_inches=\"tight\")"
+    "xml_ffs = get_xml_ffs(\n",
+    "    Path(\"../../../SPICE-SMEE/fit-v2/fits/test/fit-20250321-220547\"), base_ff\n",
+    ")\n",
+    "fig, axes = plot_param_trajectories(xml_ffs)\n",
+    "fig.savefig(\n",
+    "    \"expanded_tor_no_linear_harm_param_trajectories.png\", dpi=300, bbox_inches=\"tight\"\n",
+    ")"
    ]
   },
   {
@@ -22677,7 +22723,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xml_ffs = get_xml_ffs(Path(\"../../../SPICE-SMEE/fit-v3/fits/expanded_tor_linear/fit-20250418-135017/\"), base_ff)"
+    "xml_ffs = get_xml_ffs(\n",
+    "    Path(\"../../../SPICE-SMEE/fit-v3/fits/expanded_tor_linear/fit-20250418-135017/\"),\n",
+    "    base_ff,\n",
+    ")"
    ]
   },
   {
@@ -28588,7 +28637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": null,
    "id": "58604555",
    "metadata": {},
    "outputs": [
@@ -28604,7 +28653,7 @@
     }
    ],
    "source": [
-    "[(i, k) for i,(k,v) in enumerate(pot_types_and_param_keys)]"
+    "# [(i, k) for i, (k, v) in enumerate(pot_types_and_param_keys)]"
    ]
   },
   {
@@ -28631,12 +28680,34 @@
     }
    ],
    "source": [
-    "spice2_linear_harm.get_parameter_handler(\"ImproperTorsions\").parameters[0].to_dict()[\"k1\"]"
+    "spice2_linear_harm.get_parameter_handler(\"ImproperTorsions\").parameters[0].to_dict()[\n",
+    "    \"k1\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e063cbf7",
+   "metadata": {},
+   "source": [
+    "### The scripts below are examples and not a contiguous part of this notebook\n",
+    "\n",
+    "ff is set equal to base_ff"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": null,
+   "id": "cc17260c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ff = base_ff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "523f56fc",
    "metadata": {},
    "outputs": [
@@ -28652,12 +28723,12 @@
     }
    ],
    "source": [
-    "plot_param_trajectories_on_axes([off1, off2], [(\"Angles\", \"angle\")])"
+    "# plot_param_trajectories_on_axes([off1, off2], [(\"Angles\", \"angle\")])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "1c45918e",
    "metadata": {},
    "outputs": [
@@ -28673,7 +28744,7 @@
     }
    ],
    "source": [
-    "get_rmse_param_values([ff, ff], \"ProperTorsions\", \"k1\")"
+    "# get_rmse_param_values([ff, ff], \"ProperTorsions\", \"k1\")"
    ]
   },
   {
@@ -28704,8 +28775,14 @@
     "params = ff.get_parameter_handler(potential_type).parameters\n",
     "param_names = [f\"{p.id}_{parameter_key}\" for p in params]\n",
     "param_vals_with_units = [p.to_dict()[parameter_key] for p in params]\n",
-    "param_units = units.unit.degrees if potential_type == \"Angles\" and parameter_key == \"angle\" else param_vals_with_units[0].units\n",
-    "param_vals_unitless = np.array([float(v / param_units) for v in param_vals_with_units], dtype=np.float64)\n"
+    "param_units = (\n",
+    "    units.unit.degrees\n",
+    "    if potential_type == \"Angles\" and parameter_key == \"angle\"\n",
+    "    else param_vals_with_units[0].units\n",
+    ")\n",
+    "param_vals_unitless = np.array(\n",
+    "    [float(v / param_units) for v in param_vals_with_units], dtype=np.float64\n",
+    ")"
    ]
   },
   {

--- a/workflow/benchmark.py
+++ b/workflow/benchmark.py
@@ -2,15 +2,12 @@
 
 from pathlib import Path
 import subprocess
+import sys
 
 # from yammbs.cached_result import CachedResultCollection,CachedResult
 from openff.qcsubmit.results import OptimizationResultCollection
 import logging
-import sys
-import json
 import multiprocessing
-import tqdm
-import qcportal
 from models import WorkflowConfig
 
 import loguru
@@ -18,20 +15,28 @@ import loguru
 logger = loguru.logger
 
 
-logging.getLogger('openff').setLevel(logging.ERROR)
+logging.getLogger("openff").setLevel(logging.ERROR)
 
 SAGE22_INDUSTRY_BENCHMARK_JSON_URL = "https://raw.githubusercontent.com/openforcefield/sage-2.2.0/refs/heads/main/05_benchmark_forcefield/datasets/OpenFF-Industry-Benchmark-Season-1-v1.1-filtered-charge-coverage.json"
 
 
 # From https://github.com/openforcefield/sage-2.2.1/blob/main/05_benchmark_forcefield/cache_dataset.py
-def split_dataset_batch_for_cache(dataset,n=1):
-    ds = dict(dataset)['entries']["https://api.qcarchive.molssi.org:443/"]
+def split_dataset_batch_for_cache(dataset, n=1):
+    ds = dict(dataset)["entries"]["https://api.qcarchive.molssi.org:443/"]
     n_keys = len(ds)
-    group_size = int(n_keys/n)+1 
+    group_size = int(n_keys / n) + 1
 
     split_datasets = []
-    for group_idx in range(0,n):
-        split_datasets.append(OptimizationResultCollection(entries={"https://api.qcarchive.molssi.org:443/": ds[group_idx*group_size:(group_idx+1)*group_size]}))
+    for group_idx in range(0, n):
+        split_datasets.append(
+            OptimizationResultCollection(
+                entries={
+                    "https://api.qcarchive.molssi.org:443/": ds[
+                        group_idx * group_size : (group_idx + 1) * group_size
+                    ]
+                }
+            )
+        )
 
     return split_datasets
 
@@ -40,14 +45,14 @@ def split_dataset_batch_for_cache(dataset,n=1):
 # def cache_dataset(dataset,cache_file,n_procs=1,batch_size=500):
 #     ds = OptimizationResultCollection.parse_file(dataset)
 #     logger.info('Loaded dataset.',flush=True)
-    
+
 #     split_ds = split_dataset_batch_for_cache(ds,batch_size)
 #     logger.info("Split dataset",flush=True)
 #     logger.info(f"Number of entries in initial DS: {ds.n_results}",flush=True)
 #     logger.info(f"Number of entries in split DS:   {sum([split_ds[i].n_results for i in range(0,len(split_ds))])}",flush=True)
 #     logger.info(f'Size of each batch:              { [split_ds[i].n_results for i in range(0,len(split_ds))] }',flush=True)
-    
-    
+
+
 #     logger.info('Starting cache',flush=True)
 #     cache = []
 #     with multiprocessing.Pool(n_procs) as pool:
@@ -56,9 +61,9 @@ def split_dataset_batch_for_cache(dataset,n=1):
 #             #except qcportal.client_base.PortalRequestError:
 #             #    logger.info("Error connecting to server")
 #             #    split_ds.append(
-    
+
 #     logger.info('Done making cache',flush=True)
-    
+
 #     with open(cache_file,'w') as writefile:
 #         jsondata = json.dumps(cache,default=CachedResult.to_dict,indent=2)
 #         writefile.write(jsondata)#(cache.to_json(indent=2))
@@ -75,7 +80,9 @@ def get_sage_benchmarking_data(output_dir: str | Path) -> None:
     # Get the industry benchmark json from the Sage 2.2.0 repo
     industry_benchmark_file = output_dir / "filtered-industry.json"
     if not industry_benchmark_file.exists():
-        logger.info(f"Downloading {SAGE22_INDUSTRY_BENCHMARK_JSON_URL} to {industry_benchmark_file}")
+        logger.info(
+            f"Downloading {SAGE22_INDUSTRY_BENCHMARK_JSON_URL} to {industry_benchmark_file}"
+        )
         subprocess.run(
             [
                 "curl",
@@ -89,15 +96,18 @@ def get_sage_benchmarking_data(output_dir: str | Path) -> None:
     # Cache the dataset
     cached_industry_benchmark_file = output_dir / "filtered-industry-cached.json"
     if not cached_industry_benchmark_file.exists():
-        logger.info(f"Creating cache for {industry_benchmark_file} at {cached_industry_benchmark_file}")
-        # Use all available cores
-        n_cores = multiprocessing.cpu_count()
-        cache_dataset(
-            dataset=industry_benchmark_file,
-            cache_file=cached_industry_benchmark_file,
-            n_procs=n_cores,
-            batch_size=500,
+        logger.info(
+            f"Creating cache for {industry_benchmark_file} at {cached_industry_benchmark_file}"
         )
+        # Use all available cores
+        sys.exit("cache_dataset is not in use.")
+        # n_cores = multiprocessing.cpu_count()
+        # cache_dataset(
+        #    dataset=industry_benchmark_file,
+        #    cache_file=cached_industry_benchmark_file,
+        #    n_procs=n_cores,
+        #    batch_size=500,
+        # )
 
 
 def run_yammbs_benchmarking(config: WorkflowConfig) -> None:
@@ -108,9 +118,16 @@ def run_yammbs_benchmarking(config: WorkflowConfig) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Get the absolute path to required scripts/ files
-    yammbs_benchmark_script_path = (Path(__file__).parent / "run_yammbs_script.py").absolute()
+    yammbs_benchmark_script_path = (
+        Path(__file__).parent / "run_yammbs_script.py"
+    ).absolute()
     ff_path = (Path(__file__).parent / config.output_ff_path).absolute()
-    cached_dataset_path = (Path(__file__).parent / "benchmarking" / "benchmarking_input_data" / "filtered-industry-cached.json").absolute()
+    cached_dataset_path = (
+        Path(__file__).parent
+        / "benchmarking"
+        / "benchmarking_input_data"
+        / "filtered-industry-cached.json"
+    ).absolute()
 
     # Run benchmark script with subprocess
     args = [
@@ -159,7 +176,13 @@ def run_yammbs_benchmarking(config: WorkflowConfig) -> None:
 
     # logger.info(f"Benchmark complete. Results saved to {output_dir}", flush=True)
 
-def run_torsion_benchmark(config: WorkflowConfig, sqlite_file: str | Path, torsion_data_json: str | Path, output_dir: str | Path) -> None:
+
+def run_torsion_benchmark(
+    config: WorkflowConfig,
+    sqlite_file: str | Path,
+    torsion_data_json: str | Path,
+    output_dir: str | Path,
+) -> None:
     """Benchmark the force field on torsion data. Note that all ffs in the output ff dir will be benchmarked."""
 
     # Set up directories
@@ -189,5 +212,5 @@ def run_torsion_benchmark(config: WorkflowConfig, sqlite_file: str | Path, torsi
         args.extend(["--extra-force-fields", str(ff_file)])
 
     logger.info(f"Running benchmark with args: {args}")
-    res = subprocess.run(args, check=True, cwd=output_dir)
+    #    res = subprocess.run(args, check=True, cwd=output_dir)
     logger.info(f"Benchmark complete. Results saved to {output_dir}", flush=True)

--- a/workflow/convert_ff.py
+++ b/workflow/convert_ff.py
@@ -3,7 +3,6 @@
 from copy import deepcopy
 from pathlib import Path
 
-import descent.utils.reporting
 import loguru
 import torch
 from models import WorkflowConfig

--- a/workflow/input_ff/add_urey_bradley_terms.py
+++ b/workflow/input_ff/add_urey_bradley_terms.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import typer
 from openff.toolkit import ForceField
-from openff.toolkit.typing.engines.smirnoff.parameters import AngleType, BondType
+from openff.toolkit.typing.engines.smirnoff.parameters import AngleType
 from openff.units import unit as off_unit
 from smirnoff_plugins.handlers.valence import UreyBradleyHandler
 

--- a/workflow/plot_benchmark.py
+++ b/workflow/plot_benchmark.py
@@ -22,9 +22,7 @@ logger = loguru.logger
 logging.getLogger("openff").setLevel(logging.ERROR)
 
 # suppress divide by zero in numpy.log
-warnings.filterwarnings(
-    "ignore", message="divide by zero", category=RuntimeWarning
-)
+warnings.filterwarnings("ignore", message="divide by zero", category=RuntimeWarning)
 
 pandas.set_option("display.max_columns", None)
 

--- a/workflow/run_yammbs_script.py
+++ b/workflow/run_yammbs_script.py
@@ -19,28 +19,24 @@ import logging
 import os
 import time
 import warnings
+from multiprocessing import freeze_support
 
 import click
+import loguru
 from yammbs import MoleculeStore
-from openff.qcsubmit.results import OptimizationResultCollection
-from multiprocessing import freeze_support
+from yammbs.cached_result import CachedResultCollection
 
 # try to suppress stereo warnings - from lily's valence-fitting
 # curate-dataset.py
 logging.getLogger("openff").setLevel(logging.ERROR)
 
 # suppress divide by zero in numpy.log
-warnings.filterwarnings(
-    "ignore", message="divide by zero", category=RuntimeWarning
-)
-
-import loguru
-
-from yammbs.cached_result import CachedResultCollection
+warnings.filterwarnings("ignore", message="divide by zero", category=RuntimeWarning)
 
 logger = loguru.logger
 
 # this code is from Brent's benchmarking repo
+
 
 @click.command()
 @click.option("--forcefield", "-f", default="force-field.offxml")
@@ -56,15 +52,15 @@ def main(forcefield, dataset, sqlite_file, out_dir, procs, invalidate_cache):
         logger.info(f"loading existing database from {sqlite_file}")
         store = MoleculeStore(sqlite_file)
     else:
-        #logger.info(f"loading initial dataset from {dataset}")
-        #opt = OptimizationResultCollection.parse_file(dataset)
+        # logger.info(f"loading initial dataset from {dataset}")
+        # opt = OptimizationResultCollection.parse_file(dataset)
 
-        #logger.info(f"generating database, saving to {sqlite_file}")
-        #store = MoleculeStore.from_qcsubmit_collection(opt, sqlite_file)
-        logger.info(f"loading cached results from {dataset}",flush=True)
+        # logger.info(f"generating database, saving to {sqlite_file}")
+        # store = MoleculeStore.from_qcsubmit_collection(opt, sqlite_file)
+        logger.info(f"loading cached results from {dataset}", flush=True)
         cache = CachedResultCollection.from_json(dataset)
 
-        store=MoleculeStore.from_cached_result_collection(cache,sqlite_file)
+        store = MoleculeStore.from_cached_result_collection(cache, sqlite_file)
 
     logger.info("started optimizing store")
     start = time.time()
@@ -74,14 +70,14 @@ def main(forcefield, dataset, sqlite_file, out_dir, procs, invalidate_cache):
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
-    store.get_dde(forcefield,skip_check=True).to_csv(f"{out_dir}/dde.csv")
-    store.get_rmsd(forcefield,skip_check=True).to_csv(f"{out_dir}/rmsd.csv")
-    store.get_tfd(forcefield,skip_check=True).to_csv(f"{out_dir}/tfd.csv")
-    store.get_internal_coordinate_rmsd(forcefield,skip_check=True).to_csv(f"{out_dir}/icrmsd.csv")
-
+    store.get_dde(forcefield, skip_check=True).to_csv(f"{out_dir}/dde.csv")
+    store.get_rmsd(forcefield, skip_check=True).to_csv(f"{out_dir}/rmsd.csv")
+    store.get_tfd(forcefield, skip_check=True).to_csv(f"{out_dir}/tfd.csv")
+    store.get_internal_coordinate_rmsd(forcefield, skip_check=True).to_csv(
+        f"{out_dir}/icrmsd.csv"
+    )
 
 
 if __name__ == "__main__":
     freeze_support()
     main()
-

--- a/workflow/train.py
+++ b/workflow/train.py
@@ -164,7 +164,6 @@ def get_losses(
     )
 
     for batch in dataset_batch_iterator(dataset, config.batch_size):
-
         true_batch_size = len(dataset)
 
         cuda_batch = prepare_cuda_batch(batch)
@@ -346,7 +345,6 @@ def train(config: WorkflowConfig) -> None:
                     "train": minibatch,
                     "test": dataset_test,
                 }.items():
-
                     losses[dataset_name].extend(
                         get_losses(
                             config,


### PR DESCRIPTION
Installation failed to install pre-commit in the last stage because `conda` was used instead of `mamba`. This PR was meant to update the Makefile to autodetect the package manager and use it for all actions.

An error occurred in the last step where `--no-capture-output` was not recognized resulting in an error:
`mamba run --name descent-workflow --no-capture-output pre-commit install || true /var/folders/dr/9nnhm1493kv7_s9r_wj_l_jm0000gn/T/mambaf155lydw812: line 5: exec: --: invalid option exec: usage: exec [-cl] [-a name] file [redirection ...]`
The option `--no-capture-output` was replaced with `-a ""` which should achieve the same goal

All changes to other files were forced by a working pre-commit. I attempted to make minimum changes or add a comment if needed.